### PR TITLE
add timeago.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ Web 数据可视化工具
 * timezone-js：让 JavaScript Date 对象拥有时区功能。使用 Olson zoneinfo 文件记录着时区数据。[官网](https://github.com/mde/timezone-js)
 * date：拥有人性化的 Date() 方法。[官网](https://github.com/MatthewMueller/date)
 * ms.js：小巧的毫秒转换工具。[官网](https://github.com/rauchg/ms.js)
+* timeago.js：一个非常轻量级(~1.7 Kb)的用于将时间转化成`xxx时间前`格式，例如：8分钟前。[官网](http://timeago.org)
 
 <h3 id="string">字符串</h3>
 


### PR DESCRIPTION
[timeago.js](http://timeago.org/) is a simple library (less then 2kb) used to format date with `*** time ago` statement. eg: '3 hours ago'.
